### PR TITLE
Fix missing opening comment 

### DIFF
--- a/Part 1 - Basic GPIO/main.c
+++ b/Part 1 - Basic GPIO/main.c
@@ -1,4 +1,4 @@
-*********************************************************************************
+/*********************************************************************************
  * Copyright (c) 2021 Nanjing Qinheng Microelectronics Co., Ltd.
  * Attention: This software (modified or not) and binary are used for 
  * microcontroller manufactured by Nanjing Qinheng Microelectronics.


### PR DESCRIPTION
There is a minor typo (missing opening comment /) but this throws a slew of errors when trying to compile. 